### PR TITLE
Implement PFDTane algorithm

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -13,6 +13,7 @@ import desbordante
 class Task(StrEnum):
     fd = auto()
     afd = auto()
+    pfd = auto()
     fd_verification = auto()
     afd_verification = auto()
     mfd_verification = auto()
@@ -21,6 +22,7 @@ class Task(StrEnum):
 class Algorithm(StrEnum):
     pyro = auto()
     tane = auto()
+    pfdtane = auto()
     hyfd = auto()
     fd_mine = auto()
     dfd = auto()
@@ -142,6 +144,12 @@ F. Naumann.
 Algorithms: PYRO, TANE
 Default: PYRO
 '''
+PFD_HELP = '''Discover minimal non-trivial probabilistic functional
+dependencies.
+
+Algorithms: PFDTANE
+Default: PFDTANE
+'''
 FD_VERIFICATION_HELP = '''Verify whether a given exact functional dependency
 holds on the specified dataset. For more information about the primitive and
 algorithms, refer to the “Functional dependency discovery: an experimental
@@ -175,6 +183,11 @@ TANE_HELP = '''A classic algorithm for discovery of exact and approximate
 functional dependencies. For more information, refer to “TANE : An Efficient
 Algorithm for Discovering Functional and Approximate Dependencies” by
 Y. Huntala et al.
+'''
+PFDTANE_HELP = '''A TANE-based algorithm for discovery of probabilistic
+functional dependencies. For more information, refer to “Functional Dependency
+Generation and Applications in pay-as-you-go data integration systems” by
+Daisy Zhe Wang et al.
 '''
 HYFD_HELP = '''A modern algorithm for discovery of exact functional
 dependencies. One of the most high-performance algorithms for this task. For
@@ -244,6 +257,7 @@ OPTION_TYPES = {
 TASK_HELP_PAGES = {
     Task.fd: FD_HELP,
     Task.afd: AFD_HELP,
+    Task.pfd: PFD_HELP,
     Task.fd_verification: FD_VERIFICATION_HELP,
     Task.afd_verification: AFD_VERIFICATION_HELP,
     Task.mfd_verification: MFD_VERIFICATION_HELP
@@ -252,6 +266,7 @@ TASK_HELP_PAGES = {
 ALGO_HELP_PAGES = {
     Algorithm.pyro: PYRO_HELP,
     Algorithm.tane: TANE_HELP,
+    Algorithm.pfdtane: PFDTANE_HELP,
     Algorithm.hyfd: HYFD_HELP,
     Algorithm.fd_mine: FD_MINE_HELP,
     Algorithm.dfd: DFD_HELP,
@@ -275,6 +290,7 @@ TASK_INFO = {
                       Algorithm.hyfd),
     Task.afd: TaskInfo([Algorithm.pyro, Algorithm.tane],
                        Algorithm.pyro),
+    Task.pfd: TaskInfo([Algorithm.pfdtane], Algorithm.pfdtane),
     Task.fd_verification: TaskInfo([Algorithm.naive_fd_verifier],
                                    Algorithm.naive_fd_verifier),
     Task.afd_verification: TaskInfo([Algorithm.naive_afd_verifier],
@@ -286,6 +302,7 @@ TASK_INFO = {
 ALGOS = {
     Algorithm.pyro: desbordante.Pyro,
     Algorithm.tane: desbordante.Tane,
+    Algorithm.pfdtane: desbordante.PFDTane,
     Algorithm.hyfd: desbordante.HyFD,
     Algorithm.fd_mine: desbordante.FdMine,
     Algorithm.dfd: desbordante.DFD,

--- a/examples/comparison_pfd_vs_afd.py
+++ b/examples/comparison_pfd_vs_afd.py
@@ -1,0 +1,32 @@
+import desbordante
+
+TABLE = 'examples/datasets/inventory_afd.csv'
+ERROR = 0.2
+ERROR_MEASURE = 'per_value' # per_tuple or per_value
+
+
+def make_set(fds):
+    return set(map(str, fds))
+
+
+def get_afds():
+    algo = desbordante.Tane()
+    algo.load_data(TABLE, ',', True)
+    algo.execute(error=ERROR)
+    return algo.get_fds()
+
+
+def get_pfds():
+    algo = desbordante.PFDTane()
+    algo.load_data(TABLE, ',', True)
+    algo.set_option('error_measure', ERROR_MEASURE)
+    algo.execute(error=ERROR)
+    return algo.get_fds()
+
+
+pfds = make_set(get_pfds())
+afds = make_set(get_afds())
+
+print("pFDs \ AFDs =", pfds - afds)
+print("AFDs \ pFDs =", afds - pfds)
+print("AFDs ∩ pFDs =", afds & pfds)

--- a/examples/mining_pfd.py
+++ b/examples/mining_pfd.py
@@ -1,0 +1,14 @@
+import desbordante
+
+TABLE = 'examples/datasets/inventory_afd.csv'
+ERROR = 0.3
+ERROR_MEASURE = 'per_value' # per_tuple or per_value
+
+algo = desbordante.PFDTane()
+algo.load_data(TABLE, ',', True)
+algo.set_option('error_measure', ERROR_MEASURE)
+algo.execute(error=ERROR)
+result = algo.get_fds()
+print('pFDs:')
+for fd in result:
+    print(fd)

--- a/src/core/algorithms/algorithm_types.h
+++ b/src/core/algorithms/algorithm_types.h
@@ -9,7 +9,7 @@ namespace algos {
 using AlgorithmTypes =
         std::tuple<Depminer, DFD, FastFDs, FDep, Fd_mine, Pyro, Tane, FUN, hyfd::HyFD, Aid, Apriori,
                    metric::MetricVerifier, DataStats, fd_verifier::FDVerifier, HyUCC, PyroUCC,
-                   cfd::FDFirstAlgorithm, ACAlgorithm, UCCVerifier, Faida>;
+                   cfd::FDFirstAlgorithm, ACAlgorithm, UCCVerifier, Faida, PFDTane>;
 
 // clang-format off
 /* Enumeration of all supported non-pipeline algorithms. If you implement a new
@@ -27,6 +27,7 @@ BETTER_ENUM(AlgorithmType, char,
     fdmine,
     pyro,
     tane,
+    pfdtane,
     fun,
     hyfd,
     aidfd,

--- a/src/core/algorithms/algorithms.h
+++ b/src/core/algorithms/algorithms.h
@@ -9,6 +9,7 @@
 #include "algorithms/fd/fdep/fdep.h"
 #include "algorithms/fd/fun/fun.h"
 #include "algorithms/fd/hyfd/hyfd.h"
+#include "algorithms/fd/pfdtane/pfdtane.h"
 #include "algorithms/fd/pyro/pyro.h"
 #include "algorithms/fd/tane/tane.h"
 #include "algorithms/statistics/data_stats.h"

--- a/src/core/algorithms/fd/pfdtane/enums.h
+++ b/src/core/algorithms/fd/pfdtane/enums.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <enum.h>
+
+namespace algos {
+
+BETTER_ENUM(ErrorMeasure, char, per_tuple = 0, per_value)
+
+}

--- a/src/core/algorithms/fd/pfdtane/pfdtane.cpp
+++ b/src/core/algorithms/fd/pfdtane/pfdtane.cpp
@@ -1,4 +1,4 @@
-#include "tane.h"
+#include "pfdtane.h"
 
 #include <chrono>
 #include <iomanip>
@@ -8,63 +8,138 @@
 #include <easylogging++.h>
 
 #include "config/error/option.h"
+#include "config/error_measure/option.h"
+#include "config/error_measure/type.h"
 #include "config/max_lhs/option.h"
-#include "lattice_level.h"
-#include "lattice_vertex.h"
+#include "config/names_and_descriptions.h"
+#include "config/option.h"
+#include "enums.h"
+#include "fd/tane/lattice_level.h"
+#include "fd/tane/lattice_vertex.h"
 #include "model/table/column_data.h"
 #include "model/table/column_layout_relation_data.h"
 #include "model/table/relational_schema.h"
 
 namespace algos {
-
 using boost::dynamic_bitset;
 
-Tane::Tane() : PliBasedFDAlgorithm({kDefaultPhaseName}) {
+PFDTane::PFDTane() : algos::PliBasedFDAlgorithm({kDefaultPhaseName}) {
     RegisterOptions();
 }
 
-void Tane::RegisterOptions() {
+double PFDTane::CalculateZeroAryFdErrorPerValue(ColumnData const* rhs) {
+    size_t max = 1;
+    model::PositionListIndex const* x_index = rhs->GetPositionListIndex();
+    for (model::PositionListIndex::Cluster const& x_cluster : x_index->GetIndex()) {
+        max = std::max(max, x_cluster.size());
+    }
+    return 1.0 - static_cast<double>(max) / x_index->getRelationSize();
+}
+
+double PFDTane::CalculateFdErrorPerValue(model::PositionListIndex const* x_pli,
+                                         model::PositionListIndex const* xa_pli) {
+    auto xa_index = xa_pli->GetIndex();
+    std::shared_ptr<const std::vector<int>> probing_table = x_pli->CalculateAndGetProbingTable();
+    std::sort(xa_index.begin(), xa_index.end(),
+              [&probing_table](std::vector<int> const& a, std::vector<int> const& b) {
+                  return probing_table->at(a[0]) < probing_table->at(b[0]);
+              });
+    double sum = 0.0;
+    std::size_t cluster_rows_count = 0;
+    std::deque<model::PositionListIndex::Cluster> const& x_index = x_pli->GetIndex();
+    auto xa_cluster_it = xa_index.begin();
+
+    for (model::PositionListIndex::Cluster const& x_cluster : x_index) {
+        std::size_t max = 1;
+        for (int x_row : x_cluster) {
+            if (xa_cluster_it == xa_index.end()) {
+                break;
+            }
+            if (x_row == xa_cluster_it->at(0)) {
+                max = std::max(max, xa_cluster_it->size());
+                xa_cluster_it++;
+            }
+        }
+        sum += static_cast<double>(max) / x_cluster.size();
+        cluster_rows_count += x_cluster.size();
+    }
+    auto unique_rows = static_cast<unsigned int>(x_pli->getRelationSize() - cluster_rows_count);
+    return 1.0 - (sum + unique_rows) / (x_index.size() + unique_rows);
+}
+
+double PFDTane::CalculateZeroAryFdErrorPerTuple(ColumnData const* rhs) {
+    size_t max = 1;
+    model::PositionListIndex const* x_index = rhs->GetPositionListIndex();
+    for (model::PositionListIndex::Cluster const& x_cluster : x_index->GetIndex()) {
+        max = std::max(max, x_cluster.size());
+    }
+    return 1.0 - static_cast<double>(max) / x_index->getRelationSize();
+}
+
+double PFDTane::CalculateFdErrorPerTuple(model::PositionListIndex const* x_pli,
+                                         model::PositionListIndex const* xa_pli) {
+    auto xa_index = xa_pli->GetIndex();
+    std::shared_ptr<const std::vector<int>> probing_table = x_pli->CalculateAndGetProbingTable();
+    std::sort(xa_index.begin(), xa_index.end(),
+              [&probing_table](std::vector<int> const& a, std::vector<int> const& b) {
+                  return probing_table->at(a[0]) < probing_table->at(b[0]);
+              });
+
+    std::size_t sum = 0;
+    std::size_t cluster_rows_count = 0;
+    std::deque<model::PositionListIndex::Cluster> const& x_index = x_pli->GetIndex();
+    auto xa_cluster_it = xa_index.begin();
+
+    for (model::PositionListIndex::Cluster const& x_cluster : x_index) {
+        std::size_t max = 1;
+        for (int x_row : x_cluster) {
+            if (xa_cluster_it == xa_index.end()) {
+                break;
+            }
+            if (x_row == xa_cluster_it->at(0)) {
+                max = std::max(max, xa_cluster_it->size());
+                xa_cluster_it++;
+            }
+        }
+        sum += max;
+        cluster_rows_count += x_cluster.size();
+    }
+    auto unique_rows = static_cast<unsigned int>(x_pli->getRelationSize() - cluster_rows_count);
+    return 1.0 - static_cast<double>(sum + unique_rows) / x_pli->getRelationSize();
+}
+
+void PFDTane::RegisterOptions() {
     RegisterOption(config::ErrorOpt(&max_ucc_error_));
+    RegisterOption(config::ErrorMeasureOpt(&error_measure_));
     RegisterOption(config::MaxLhsOpt(&max_lhs_));
 }
 
-void Tane::MakeExecuteOptsAvailable() {
-    MakeOptionsAvailable({config::MaxLhsOpt.GetName(), config::ErrorOpt.GetName()});
+void PFDTane::MakeExecuteOptsAvailable() {
+    MakeOptionsAvailable({config::MaxLhsOpt.GetName(), config::ErrorOpt.GetName(),
+                          config::ErrorMeasureOpt.GetName()});
 }
 
-void Tane::ResetStateFd() {
+void PFDTane::ResetStateFd() {
     count_of_fd_ = 0;
     count_of_ucc_ = 0;
     apriori_millis_ = 0;
 }
 
-double Tane::CalculateZeroAryFdError(ColumnData const* rhs,
-                                     ColumnLayoutRelationData const* relation_data) {
-    return 1 - rhs->GetPositionListIndex()->GetNepAsLong() /
-                       static_cast<double>(relation_data->GetNumTuplePairs());
-}
-
-double Tane::CalculateFdError(model::PositionListIndex const* lhs_pli,
-                              model::PositionListIndex const* joint_pli,
-                              ColumnLayoutRelationData const* relation_data) {
-    return (double)(lhs_pli->GetNepAsLong() - joint_pli->GetNepAsLong()) /
-           static_cast<double>(relation_data->GetNumTuplePairs());
-}
-
-double Tane::CalculateUccError(model::PositionListIndex const* pli,
-                               ColumnLayoutRelationData const* relation_data) {
+double PFDTane::CalculateUccError(model::PositionListIndex const* pli,
+                                  ColumnLayoutRelationData const* relation_data) {
     return pli->GetNepAsLong() / static_cast<double>(relation_data->GetNumTuplePairs());
 }
 
-void Tane::RegisterAndCountFd(Vertical const& lhs, Column const* rhs, [[maybe_unused]] double error,
-                              [[maybe_unused]] RelationalSchema const* schema) {
+void PFDTane::RegisterAndCountFd(Vertical const& lhs, Column const* rhs,
+                                 [[maybe_unused]] double error,
+                                 [[maybe_unused]] RelationalSchema const* schema) {
     dynamic_bitset<> lhs_bitset = lhs.GetColumnIndices();
     PliBasedFDAlgorithm::RegisterFd(lhs, *rhs);
     count_of_fd_++;
 }
 
-void Tane::RegisterUcc([[maybe_unused]] Vertical const& key, [[maybe_unused]] double error,
-                       [[maybe_unused]] RelationalSchema const* schema) {
+void PFDTane::RegisterUcc([[maybe_unused]] Vertical const& key, [[maybe_unused]] double error,
+                          [[maybe_unused]] RelationalSchema const* schema) {
     /*dynamic_bitset<> key_bitset = key.getColumnIndices();
     LOG(INFO) << "Discovered UCC: ";
     for (int i = key_bitset.find_first(); i != -1; i = key_bitset.find_next(i)) {
@@ -74,9 +149,19 @@ void Tane::RegisterUcc([[maybe_unused]] Vertical const& key, [[maybe_unused]] do
     count_of_ucc_++;
 }
 
-unsigned long long Tane::ExecuteInternal() {
+model::PositionListIndex* PFDTane::GetColumnIndex(unsigned int column) {
+    return relation_->GetColumnData(column).GetPositionListIndex();
+}
+
+unsigned long long PFDTane::ExecuteInternal() {
     max_fd_error_ = max_ucc_error_;
     RelationalSchema const* schema = relation_->GetSchema();
+    auto calculate_fd_error = error_measure_ == +ErrorMeasure::per_tuple
+                                      ? &PFDTane::CalculateFdErrorPerTuple
+                                      : &PFDTane::CalculateFdErrorPerValue;
+    auto calculate_fd_zero_ary_error = error_measure_ == +ErrorMeasure::per_tuple
+                                               ? &PFDTane::CalculateZeroAryFdErrorPerTuple
+                                               : &PFDTane::CalculateZeroAryFdErrorPerValue;
 
     LOG(INFO) << schema->GetName() << " has " << relation_->GetNumColumns() << " columns, "
               << relation_->GetNumRows() << " rows, and a maximum NIP of " << std::setw(2)
@@ -116,7 +201,7 @@ unsigned long long Tane::ExecuteInternal() {
         vertex->SetPositionListIndex(column_data.GetPositionListIndex());
 
         // check FDs: 0->A
-        double fd_error = CalculateZeroAryFdError(&column_data, relation_.get());
+        double fd_error = (this->*calculate_fd_zero_ary_error)(&column_data);
         if (fd_error <= max_fd_error_) {  // TODO: max_error
             zeroary_fd_rhs.set(column->GetIndex());
             RegisterAndCountFd(*schema->empty_vertical_, column.get(), fd_error, schema);
@@ -193,7 +278,7 @@ unsigned long long Tane::ExecuteInternal() {
 
             dynamic_bitset<> xa_indices = xa.GetColumnIndices();
             dynamic_bitset<> a_candidates = xa_vertex->GetRhsCandidates();
-
+            auto xa_pli = xa_vertex->GetPositionListIndex();
             for (auto const& x_vertex : xa_vertex->GetParents()) {
                 Vertical const& lhs = x_vertex->GetVertical();
 
@@ -208,10 +293,10 @@ unsigned long long Tane::ExecuteInternal() {
                 if (!a_candidates[a_index]) {
                     continue;
                 }
+                auto x_pli = x_vertex->GetPositionListIndex();
 
                 // Check X -> A
-                double error = CalculateFdError(x_vertex->GetPositionListIndex(),
-                                                xa_vertex->GetPositionListIndex(), relation_.get());
+                double error = (this->*calculate_fd_error)(x_pli, xa_pli);
                 if (error <= max_fd_error_) {
                     Column const* rhs = schema->GetColumns()[a_index].get();
 

--- a/src/core/algorithms/fd/pfdtane/pfdtane.h
+++ b/src/core/algorithms/fd/pfdtane/pfdtane.h
@@ -2,38 +2,35 @@
 
 #include <string>
 
-#include "algorithms/fd/pli_based_fd_algorithm.h"
-#include "config/error/type.h"
-#include "config/max_lhs/type.h"
+#include "algorithms/fd/tane/tane.h"
+#include "config/error_measure/type.h"
+#include "enums.h"
 #include "model/table/position_list_index.h"
 #include "model/table/relation_data.h"
 
 namespace algos {
 
-class Tane : public PliBasedFDAlgorithm {
+class PFDTane : public PliBasedFDAlgorithm {
 private:
+    void ResetStateFd() final;
     void RegisterOptions();
     void MakeExecuteOptsAvailable() final;
-
-    void ResetStateFd() final;
-    unsigned long long ExecuteInternal() final;
+    unsigned long long ExecuteInternal() override final;
 
 public:
     config::ErrorType max_fd_error_;
     config::ErrorType max_ucc_error_;
     config::MaxLhsType max_lhs_;
+    ErrorMeasure error_measure_ = ErrorMeasure::_values()[0];
 
     int count_of_fd_ = 0;
     int count_of_ucc_ = 0;
     long apriori_millis_ = 0;
 
-    Tane();
+    PFDTane();
 
-    static double CalculateZeroAryFdError(ColumnData const* rhs,
-                                          ColumnLayoutRelationData const* relation_data);
-    static double CalculateFdError(model::PositionListIndex const* lhs_pli,
-                                   model::PositionListIndex const* joint_pli,
-                                   ColumnLayoutRelationData const* relation_data);
+    model::PositionListIndex* GetColumnIndex(unsigned int column);  // for test
+
     static double CalculateUccError(model::PositionListIndex const* pli,
                                     ColumnLayoutRelationData const* relation_data);
 
@@ -44,6 +41,13 @@ public:
     // void RegisterFd(Vertical const* lhs, Column const* rhs, double error, RelationalSchema const*
     // schema);
     void RegisterUcc(Vertical const& key, double error, RelationalSchema const* schema);
+
+    double CalculateZeroAryFdErrorPerValue(ColumnData const* rhs);
+    double CalculateFdErrorPerValue(model::PositionListIndex const* x_pli,
+                                    model::PositionListIndex const* xa_pli);
+    double CalculateZeroAryFdErrorPerTuple(ColumnData const* rhs);
+    double CalculateFdErrorPerTuple(model::PositionListIndex const* x_pli,
+                                    model::PositionListIndex const* xa_pli);
 };
 
 }  // namespace algos

--- a/src/core/config/descriptions.h
+++ b/src/core/config/descriptions.h
@@ -19,6 +19,7 @@ constexpr auto kDThreads =
         "number of threads to use. If 0, then as many threads are used as the "
         "hardware can handle concurrently.";
 constexpr auto kDError = "error threshold value for Approximate FD algorithms";
+constexpr auto kDErrorMeasure = "error measure for Approximate FD algorithms";
 constexpr auto kDMaximumLhs = "max considered LHS size";
 constexpr auto kDSeed = "RNG seed";
 constexpr auto kDMinimumSupport = "minimum support value (between 0 and 1)";

--- a/src/core/config/error_measure/option.cpp
+++ b/src/core/config/error_measure/option.cpp
@@ -1,0 +1,20 @@
+#include "config/error_measure/option.h"
+
+#include "config/exceptions.h"
+#include "config/names_and_descriptions.h"
+#include "fd/pfdtane/enums.h"
+
+namespace config {
+using names::kErrorMeasure, descriptions::kDErrorMeasure;
+extern CommonOption<ErrorMeasureType> const ErrorMeasureOpt{
+        kErrorMeasure,
+        kDErrorMeasure,
+        algos::ErrorMeasure::_values()[0],
+        {},
+        [](ErrorMeasureType error) {
+            if (!(error == +algos::ErrorMeasure::per_value ||
+                  error == +algos::ErrorMeasure::per_tuple)) {
+                throw ConfigurationError("ERROR: error function can be per_value or per_tuple");
+            }
+        }};
+}  // namespace config

--- a/src/core/config/error_measure/option.h
+++ b/src/core/config/error_measure/option.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "config/common_option.h"
+#include "config/error_measure/type.h"
+
+namespace config {
+
+extern CommonOption<ErrorMeasureType> const ErrorMeasureOpt;
+
+}  // namespace config

--- a/src/core/config/error_measure/type.h
+++ b/src/core/config/error_measure/type.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <string>
+
+#include "fd/pfdtane/enums.h"
+
+namespace config {
+using ErrorMeasureType = algos::ErrorMeasure;
+}  // namespace config

--- a/src/core/config/names.h
+++ b/src/core/config/names.h
@@ -10,6 +10,7 @@ constexpr auto kHasHeader = "has_header";
 constexpr auto kEqualNulls = "is_null_equal_null";
 constexpr auto kThreads = "threads";
 constexpr auto kError = "error";
+constexpr auto kErrorMeasure = "error_measure";
 constexpr auto kMaximumLhs = "max_lhs";
 constexpr auto kSeed = "seed";
 constexpr auto kMinimumSupport = "minsup";

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -78,6 +78,7 @@ namespace py = pybind11;
 using PyApriori = PyArAlgorithm<algos::Apriori>;
 // FD mining algorithms
 using PyTane = PyFDAlgorithm<algos::Tane>;
+using PyPFDTane = PyFDAlgorithm<algos::PFDTane>;
 using PyPyro = PyFDAlgorithm<algos::Pyro>;
 using PyFUN = PyFDAlgorithm<algos::FUN>;
 using PyFdMine = PyFDAlgorithm<algos::Fd_mine>;
@@ -264,6 +265,7 @@ PYBIND11_MODULE(desbordante, module) {
     DEFINE_FD_ALGORITHM(HyFD);
     DEFINE_FD_ALGORITHM(Pyro);
     DEFINE_FD_ALGORITHM(Tane);
+    DEFINE_FD_ALGORITHM(PFDTane);
 
     DEFINE_UCC_ALGORITHM(HyUCC);
     DEFINE_UCC_ALGORITHM(PyroUCC);

--- a/src/python_bindings/get_py_type.cpp
+++ b/src/python_bindings/get_py_type.cpp
@@ -9,6 +9,7 @@
 
 #include "algorithms/metric/enums.h"
 #include "association_rules/ar_algorithm_enums.h"
+#include "config/error_measure/type.h"
 #include "config/tabular_data/input_table_type.h"
 
 namespace py = pybind11;
@@ -69,6 +70,7 @@ py::tuple GetPyType(std::type_index type_index) {
             PyTypePair<long double, py_float>,
             PyTypePair<algos::metric::Metric, py_str>,
             PyTypePair<algos::metric::MetricAlgo, py_str>,
+            PyTypePair<config::ErrorMeasureType, py_str>,
             PyTypePair<algos::InputFormat, py_str>,
             PyTypePair<std::vector<unsigned int>, py_list, py_int>,
             {typeid(config::InputTable),

--- a/src/python_bindings/py_to_any.cpp
+++ b/src/python_bindings/py_to_any.cpp
@@ -9,6 +9,7 @@
 #include "algorithms/algebraic_constraints/bin_operation_enum.h"
 #include "algorithms/metric/enums.h"
 #include "association_rules/ar_algorithm_enums.h"
+#include "config/error_measure/type.h"
 #include "config/exceptions.h"
 #include "config/tabular_data/input_table_type.h"
 #include "create_dataframe_reader.h"
@@ -105,6 +106,7 @@ std::unordered_map<std::type_index, ConvFunc> const converters{
         NormalConvPair<size_t>,
         EnumConvPair<algos::metric::Metric>,
         EnumConvPair<algos::metric::MetricAlgo>,
+        EnumConvPair<config::ErrorMeasureType>,
         EnumConvPair<algos::InputFormat>,
         CharEnumConvPair<algos::Binop>,
         {typeid(config::InputTable), InputTableToAny},

--- a/src/tests/test_fd_algorithm.cpp
+++ b/src/tests/test_fd_algorithm.cpp
@@ -12,6 +12,7 @@
 #include "algorithms/fd/fdep/fdep.h"
 #include "algorithms/fd/fun/fun.h"
 #include "algorithms/fd/hyfd/hyfd.h"
+#include "algorithms/fd/pfdtane/pfdtane.h"
 #include "algorithms/fd/pyro/pyro.h"
 #include "algorithms/fd/tane/tane.h"
 #include "model/table/relational_schema.h"
@@ -128,8 +129,9 @@ REGISTER_TYPED_TEST_SUITE_P(AlgorithmTest, ThrowsOnEmpty, ReturnsEmptyOnSingleNo
                             WorksOnLongDataset, WorksOnWideDataset, LightDatasetsConsistentHash,
                             HeavyDatasetsConsistentHash, ConsistentRepeatedExecution);
 
-using Algorithms = ::testing::Types<algos::Tane, algos::Pyro, algos::FastFDs, algos::DFD,
-                                    algos::Depminer, algos::FDep, algos::FUN, algos::hyfd::HyFD>;
+using Algorithms =
+        ::testing::Types<algos::Tane, algos::PFDTane, algos::Pyro, algos::FastFDs, algos::DFD,
+                         algos::Depminer, algos::FDep, algos::FUN, algos::hyfd::HyFD>;
 INSTANTIATE_TYPED_TEST_SUITE_P(AlgorithmTest, AlgorithmTest, Algorithms);
 
 }  // namespace tests

--- a/src/tests/test_pfdtane.cpp
+++ b/src/tests/test_pfdtane.cpp
@@ -1,0 +1,95 @@
+#include <algorithm>
+#include <filesystem>
+
+#include <gtest/gtest.h>
+
+#include "algo_factory.h"
+#include "config/names.h"
+#include "fd/pfdtane/enums.h"
+#include "fd/pfdtane/pfdtane.h"
+#include "table_config.h"
+
+namespace tests {
+namespace onam = config::names;
+
+struct PFDTaneParams {
+    algos::StdParamsMap params;
+    long double const error = 0.;
+    std::string result;
+
+    PFDTaneParams(std::string result, double const error = 0.,
+                  algos::ErrorMeasure error_measure = +algos::ErrorMeasure::per_tuple,
+                  char const *dataset = "TestFD.csv", char const separator = ',',
+                  bool const has_header = true)
+        : params({{onam::kCsvPath, test_data_dir / dataset},
+                  {onam::kSeparator, separator},
+                  {onam::kHasHeader, has_header},
+                  {onam::kError, error},
+                  {onam::kErrorMeasure, error_measure},
+                  {onam::kEqualNulls, true}}),
+          error(error),
+          result(result) {}
+};
+
+class TestPFDTane : public ::testing::TestWithParam<PFDTaneParams> {};
+
+TEST_P(TestPFDTane, DefaultTest) {
+    auto const &p = GetParam();
+    auto mp = algos::StdParamsMap(p.params);
+    auto algos = algos::CreateAndLoadAlgorithm<algos::PFDTane>(mp);
+    algos->Execute();
+    EXPECT_EQ(p.result, algos->GetJsonFDs());
+}
+
+TEST_P(TestPFDTane, PerTupleTest) {
+    auto const &p = GetParam();
+    auto mp = algos::StdParamsMap(p.params);
+    mp[onam::kErrorMeasure] = +algos::ErrorMeasure::per_tuple;
+    auto algos = algos::CreateAndLoadAlgorithm<algos::PFDTane>(mp);
+
+    std::vector<std::pair<int, int>> cols = {{2, 3}, {4, 5}, {3, 2}, {0, 1},
+                                             {1, 0}, {4, 3}, {1, 5}, {5, 1}};
+    std::vector<double> errors = {0.083333, 0.333333, 0.5, 0.75, 0.0, 0.083333, 0.416666, 0.0};
+    double eps = 0.0001;
+
+    for (std::size_t i = 0; i < cols.size(); i++) {
+        double error = algos->CalculateFdErrorPerTuple(
+                algos->GetColumnIndex(cols[i].first),
+                algos->GetColumnIndex(cols[i].first)
+                        ->Intersect(algos->GetColumnIndex(cols[i].second))
+                        .get());
+        EXPECT_NEAR(error, errors[i], eps);
+    }
+}
+
+TEST_P(TestPFDTane, PerValueTest) {
+    auto const &p = GetParam();
+    auto mp = algos::StdParamsMap(p.params);
+    mp[onam::kErrorMeasure] = +algos::ErrorMeasure::per_value;
+    auto algos = algos::CreateAndLoadAlgorithm<algos::PFDTane>(mp);
+
+    std::vector<std::pair<int, int>> cols = {{2, 3}, {4, 5}, {3, 2}, {0, 1},
+                                             {1, 0}, {4, 3}, {1, 5}, {5, 1}};
+    std::vector<double> errors = {0.0625, 0.333333, 0.291666, 0.75, 0.0, 0.099999, 0.416666, 0.0};
+    double eps = 0.0001;
+
+    for (std::size_t i = 0; i < cols.size(); i++) {
+        double error = algos->CalculateFdErrorPerValue(
+                algos->GetColumnIndex(cols[i].first),
+                algos->GetColumnIndex(cols[i].first)
+                        ->Intersect(algos->GetColumnIndex(cols[i].second))
+                        .get());
+        EXPECT_NEAR(error, errors[i], eps);
+    }
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(
+        PFDTaneTestSuite, TestPFDTane,
+        ::testing::Values(
+            PFDTaneParams(R"({"fds": [{"lhs": [1,4], "rhs": 2},{"lhs": [1,4], "rhs": 5},{"lhs": [1], "rhs": 3},{"lhs": [1], "rhs": 4},{"lhs": [2], "rhs": 1},{"lhs": [2], "rhs": 3},{"lhs": [2], "rhs": 4},{"lhs": [2], "rhs": 5},{"lhs": [3], "rhs": 1},{"lhs": [3], "rhs": 2},{"lhs": [3], "rhs": 4},{"lhs": [3], "rhs": 5},{"lhs": [4], "rhs": 1},{"lhs": [4], "rhs": 3},{"lhs": [5], "rhs": 1},{"lhs": [5], "rhs": 2},{"lhs": [5], "rhs": 3},{"lhs": [5], "rhs": 4},{"lhs": [], "rhs": 0}]})", 0.3, +algos::ErrorMeasure::per_value)
+        ));
+
+// clang-format on
+
+}  // namespace tests

--- a/src/tests/test_typo_miner.cpp
+++ b/src/tests/test_typo_miner.cpp
@@ -124,6 +124,7 @@ template <typename F>
 static void TestForEachAlgo(F&& test) {
     for (algos::AlgorithmType const algorithm_type :
          algos::GetAllDerived<algos::PliBasedFDAlgorithm>()) {
+        if (algorithm_type._to_index() == algos::AlgorithmType::pfdtane) continue;
         try {
             test(algorithm_type);
         } catch (std::runtime_error const& e) {


### PR DESCRIPTION
Implement Tane-based algorithm for pFDs mining.
Add tests for PerValue and PerTuple error calculation methods. Add python bindings and CLI support with error_measure option. Add basic examples of pFDs mining and comparision to AFDs.